### PR TITLE
updated instructions for pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Before using this script, make sure you have the following:
 
  - 'Parity Check Tuning' plugin by Dave Walker (itimpi)
  - Tautulli docker container by JonnyWong16
- - The required Python packages installed in the Tautulli container: `requests`, `re`, `qbittorrentapi`, `paramiko`. (create a user script that runs at the start of the array with the following: `docker exec tautulli pip install requests qbittorrentapi paramiko`)
+ - The required Python packages installed in the Tautulli container: `requests`, `re`, `qbittorrentapi`, `paramiko`. (create a user script that runs at the start of the array with the following: `docker exec tautulli pip install requests qbittorrent-api paramiko`)
 
 ## Setup
 


### PR DESCRIPTION
would fail trying to execute ```docker exec tautulli pip install requests qbittorrentapi paramiko``` changing *qbittorrentapi* to *qbittorrent-api* fixes the issue